### PR TITLE
Add linux-aarch64 platform support

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,5 +1,6 @@
 build_platform:
   osx_arm64: osx_64
+  linux_aarch64: linux_aarch64
 conda_build:
   pkg_format: '2'
 conda_forge_output_validation: true


### PR DESCRIPTION
I noticed that we are building any packages for
linux aarch64.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
